### PR TITLE
:wrench: Fixed development db's posts not called issue

### DIFF
--- a/pages/api/posts/index.ts
+++ b/pages/api/posts/index.ts
@@ -35,7 +35,8 @@ export const getPageInfo = async (id: string) => {
         .start_date,
       recordMap.block[key].value.properties['B|X?'].at(0).at(0).split(','),
       recordMap.block[key].value.format.page_cover,
-      recordMap.block[key].value.properties['k<e;'],
+      recordMap.block[key].value.properties['k<e;'] ||
+        recordMap.block[key].value.properties['{~a^'],
     ]);
   const result = {
     id,
@@ -77,5 +78,7 @@ export default async function postHandler(
       }
     })
   );
-  res.send({ posts });
+  res.send({
+    posts,
+  });
 }


### PR DESCRIPTION
The key of different dbs'(published state) gets changed dynamically.
- It is solved by finding corresponding key one-by-one
- This is not a reusable solution

> I think It will be solved by migrating to official notion api (using @notionhq/client library)